### PR TITLE
Fix building for VS16 on release mode (#1087)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class GlewConan(ConanFile):
     homepage = "http://github.com/nigels-com/glew"
     license = "MIT"
     exports = ["LICENSE.md"]
-    exports_sources = ["CMakeLists.txt", "FindGLEW.cmake"]
+    exports_sources = ["CMakeLists.txt", "FindGLEW.cmake", "vs16-release-fix.patch"]
     generators = "cmake"
     settings = "os", "arch", "build_type", "compiler"
     options = {"shared": [True, False]}
@@ -28,6 +28,8 @@ class GlewConan(ConanFile):
         release_name = "%s-%s" % (self.name, self.version)
         tools.get("{0}/releases/download/{1}/{1}.tgz".format(self.homepage, release_name), sha256="04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95")
         os.rename(release_name, self._source_subfolder)
+        # Fix build for Visual Studio 16 Release (issue #1087)
+        tools.patch(base_path=self._source_subfolder, patch_file="vs16-release-fix.patch")
         tools.replace_in_file("%s/build/cmake/CMakeLists.txt" % self._source_subfolder, "include(GNUInstallDirs)",
 """
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/vs16-release-fix.patch
+++ b/vs16-release-fix.patch
@@ -1,0 +1,12 @@
+diff -Nuar a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+--- a/build/cmake/CMakeLists.txt	2020-01-23 04:02:19.297625325 +0300
++++ b/build/cmake/CMakeLists.txt	2020-01-23 04:02:57.444622827 +0300
+@@ -109,6 +109,8 @@
+   target_compile_options (glew_s PRIVATE -GS-)
+   # remove stdlib dependency
+   target_link_libraries (glew LINK_PRIVATE -nodefaultlib -noentry)
++  target_link_libraries (glew LINK_PRIVATE libvcruntime.lib)
++  target_link_libraries (glew LINK_PRIVATE msvcrt.lib )
+   string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+ elseif (WIN32 AND ((CMAKE_C_COMPILER_ID MATCHES "GNU") OR (CMAKE_C_COMPILER_ID MATCHES "Clang")))
+   # remove stdlib dependency on windows with GCC and Clang (for similar reasons


### PR DESCRIPTION
Patching CMakeLists.txt which adds linking libraries.
See https://github.com/nigels-com/glew/issues/180 and
https://github.com/nigels-com/glew/commit/4bbe8aa2ab70a6eb847ee5751735422d0ba623cd#diff-2f38feedf9af0f5288a86bd6f203d7ea

Fixes https://github.com/bincrafters/community/issues/1087